### PR TITLE
docs: expand text parsing topic

### DIFF
--- a/text_parsing_regexp/README.md
+++ b/text_parsing_regexp/README.md
@@ -1,9 +1,78 @@
 # Parsing textual e regex
 
-Este tópico cobre parsing progressivo com scanner e extração com expressões regulares.
+Texto solto aparece em log, arquivo de configuração simples, saída de comando e payload legado. Antes de sair enfiando `strings.Split` em tudo, vale separar duas coisas: leitura linha a linha e extração do pedaço que interessa.
+
+Este tópico usa só biblioteca padrão:
+
+- `bufio.Scanner` para ler o texto uma linha por vez;
+- `regexp` para reconhecer linhas no formato `chave=valor`;
+- `strings` para limpar espaços e ignorar comentários simples;
+- `slices` para imprimir o resultado em ordem estável.
+
+## Pré-requisitos
+
+- Go instalado.
+- Conhecimento básico de mapas e funções.
+- Noção de que regex serve bem para formato pequeno e previsível. Para gramática de verdade, use um parser de verdade. Regex não precisa apanhar por uma tarefa que não é dela.
+
+## Exemplo
+
+O exemplo lê um texto com linhas válidas, comentário e uma linha inválida:
+
+```text
+app=go-study
+mode=dev
+# ignored
+invalid-line
+workers=4
+```
+
+A função `ParseKeyValues` devolve um mapa com as linhas que casam com `chave=valor`. Linhas vazias, comentários e lixo ficam de fora.
+
+```go
+parsed, err := ParseKeyValues(data)
+if err != nil {
+    panic(err)
+}
+```
+
+Mesmo lendo de uma `string`, o exemplo trata `scanner.Err()`. É hábito bom: quando a fonte muda para arquivo, pipe ou rede, o erro já tem caminho para aparecer.
+
+## Rodar
+
+```bash
+go run .
+```
+
+Saída esperada:
+
+```text
+app=go-study
+mode=dev
+workers=4
+```
 
 ## Testar
 
 ```bash
-go test ./...
+go test -timeout 30s -count 1 ./...
 ```
+
+## Pontos de atenção
+
+`bufio.Scanner` é ótimo para linha pequena. O limite padrão de token é 64 KiB; se você pretende ler linha gigante, configure `scanner.Buffer` ou use `bufio.Reader`.
+
+Regex também tem limite prático. O padrão deste tópico aceita chave com letras, números e `_`, e valor sem outro `=`. Isso é uma regra didática, não um formato universal.
+
+## Erros comuns
+
+- Usar `Split(line, "=")` e quebrar valor que contém `=` sem perceber.
+- Ignorar `scanner.Err()` porque o exemplo começou lendo uma string.
+- Fazer regex grande demais para compensar um formato mal definido.
+- Depender da ordem de iteração do mapa. Mapa em Go não tem ordem estável; por isso o exemplo ordena as chaves antes de imprimir.
+
+## Próximos passos
+
+- Trocar a entrada de `string` por um arquivo aberto com `os.Open`.
+- Aceitar espaços ao redor do `=` se o formato pedir isso.
+- Comparar este exemplo com `encoding/csv` quando o dado tiver colunas de verdade.

--- a/text_parsing_regexp/main.go
+++ b/text_parsing_regexp/main.go
@@ -10,27 +10,45 @@ import (
 
 var keyValuePattern = regexp.MustCompile(`^([a-zA-Z0-9_]+)=([^=]+)$`)
 
-func ParseKeyValues(data string) map[string]string {
+func ParseKeyValues(data string) (map[string]string, error) {
 	out := map[string]string{}
-	s := bufio.NewScanner(strings.NewReader(data))
-	for s.Scan() {
-		m := keyValuePattern.FindStringSubmatch(strings.TrimSpace(s.Text()))
-		if len(m) == 3 {
-			out[m[1]] = m[2]
+	scanner := bufio.NewScanner(strings.NewReader(data))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
 		}
+
+		match := keyValuePattern.FindStringSubmatch(line)
+		if len(match) != 3 {
+			continue
+		}
+
+		out[match[1]] = match[2]
 	}
-	return out
+
+	err := scanner.Err()
+	if err != nil {
+		return nil, err
+	}
+
+	return out, nil
 }
 
 func main() {
-	data := "app=go-study\nmode=dev\ninvalid-line\nworkers=4\n"
-	parsed := ParseKeyValues(data)
-	keys := make([]string, 0, len(parsed))
-	for k := range parsed {
-		keys = append(keys, k)
+	data := "app=go-study\nmode=dev\n# ignored\ninvalid-line\nworkers=4\n"
+	parsed, err := ParseKeyValues(data)
+	if err != nil {
+		panic(err)
 	}
+
+	keys := make([]string, 0, len(parsed))
+	for key := range parsed {
+		keys = append(keys, key)
+	}
+
 	slices.Sort(keys)
-	for _, k := range keys {
-		fmt.Printf("%s=%s\n", k, parsed[k])
+	for _, key := range keys {
+		fmt.Printf("%s=%s\n", key, parsed[key])
 	}
 }

--- a/text_parsing_regexp/main_test.go
+++ b/text_parsing_regexp/main_test.go
@@ -1,11 +1,22 @@
 package main
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestParseKeyValues(t *testing.T) {
-	in := "a=1\ninvalid\nb=2\n"
-	got := ParseKeyValues(in)
-	if got["a"] != "1" || got["b"] != "2" {
-		t.Fatalf("unexpected map: %#v", got)
+	in := "a=1\ninvalid\n# comment\n\nb=2\n"
+	got, err := ParseKeyValues(in)
+	if err != nil {
+		t.Fatalf("ParseKeyValues() error = %v", err)
+	}
+
+	want := map[string]string{
+		"a": "1",
+		"b": "2",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ParseKeyValues() = %#v, want %#v", got, want)
 	}
 }


### PR DESCRIPTION
## O que mudou

Expandi o tópico `text_parsing_regexp` para ficar mais perto do padrão dos tópicos novos:

- README com objetivo, pré-requisitos, comandos de execução e pontos de atenção.
- Exemplo usando só biblioteca padrão: `bufio.Scanner`, `regexp`, `strings` e `slices`.
- Tratamento explícito de `scanner.Err()`.
- Teste cobrindo linha inválida, comentário e linha vazia.

## Por quê

O README anterior estava correto, mas curto demais para estudo guiado. Parsing textual é uma daquelas partes em que `strings.Split` resolve até o dia em que não resolve. O exemplo mantém a regra pequena: linhas `chave=valor`, comentário com `#`, lixo ignorado.

## O que não faz

Não tenta criar um parser genérico. Também não aceita espaço ao redor do `=`. Se o formato crescer, esse é outro tópico.

## Validação

Rodado dentro de `text_parsing_regexp`:

```bash
go fix ./...
go fix -inline ./...
gofmt -l .
go vet ./...
golangci-lint run ./...
gosec ./...
go test -timeout 30s -count 1 ./...
go run .
```
