### PR TITLE
docs: expand checksums topic

### DIFF
--- a/checksums/README.md
+++ b/checksums/README.md
@@ -1,9 +1,48 @@
 # Checksums
 
-Este tópico cobre `crc32` e `crc64` para verificação básica de integridade.
+Checksum serve para detectar corrupção acidental: arquivo truncado, byte trocado no download, cópia quebrada em disco. Não é assinatura, não é senha, não prova autoria. CRC é rápido e bom para erro bobo; para comparar conteúdo com menos chance de colisão, use um hash criptográfico como `SHA-256`.
+
+O exemplo usa três funções da biblioteca padrão:
+
+- `hash/crc32`, comum em formatos antigos, rede e validação simples;
+- `hash/crc64`, útil quando você quer um CRC maior sem mudar de família;
+- `crypto/sha256`, melhor quando o identificador do conteúdo precisa ser mais forte que um CRC.
+
+## Pré-requisitos
+
+- Go 1.26 ou mais recente.
+- Terminal no diretório `checksums`.
+
+## Executar
+
+```bash
+go run .
+```
+
+Saída esperada:
+
+```text
+crc32  d57bb496
+crc64  5ca2c9f6a56b90c2
+sha256 5caa2109d58ce3fefe483e8b7176b80a00485ecbb3d92b18e48204a6ed4fe876
+```
 
 ## Testar
 
 ```bash
-go test ./...
+go test -timeout 30s -count 1 ./...
 ```
+
+Os testes usam o payload fixo `invoice:42:paid`. Isso deixa o exemplo chato de propósito: se alguém trocar a tabela do CRC64, mudar o formato hexadecimal ou mexer no payload sem perceber, o teste quebra.
+
+## Pontos de atenção
+
+- CRC detecta erro acidental, mas não resiste a alteração maliciosa. Se a entrada vem de alguém que pode atacar o sistema, CRC sozinho é a ferramenta errada.
+- `sha256.Sum256` retorna um array de 32 bytes. Para imprimir ou gravar em texto, formate em hexadecimal com `%x`.
+- Não compare checksums de texto antes de decidir a codificação e as quebras de linha. `\n` e `\r\n` geram valores diferentes.
+
+## Próximos passos
+
+- Calcular o checksum lendo de um arquivo com `io.Copy` e `hash.Hash`.
+- Comparar o custo entre CRC32, CRC64 e SHA-256 com benchmark.
+- Usar `hmac` quando a verificação também precisa de uma chave compartilhada.

--- a/checksums/main.go
+++ b/checksums/main.go
@@ -1,15 +1,31 @@
 package main
 
 import (
+	"crypto/sha256"
+	"fmt"
 	"hash/crc32"
 	"hash/crc64"
 )
+
+var crc64Table = crc64.MakeTable(crc64.ISO)
 
 func CRC32(data []byte) uint32 {
 	return crc32.ChecksumIEEE(data)
 }
 
 func CRC64(data []byte) uint64 {
-	table := crc64.MakeTable(crc64.ISO)
-	return crc64.Checksum(data, table)
+	return crc64.Checksum(data, crc64Table)
+}
+
+func SHA256(data []byte) string {
+	sum := sha256.Sum256(data)
+	return fmt.Sprintf("%x", sum)
+}
+
+func main() {
+	payload := []byte("invoice:42:paid")
+
+	fmt.Printf("crc32  %08x\n", CRC32(payload))
+	fmt.Printf("crc64  %016x\n", CRC64(payload))
+	fmt.Printf("sha256 %s\n", SHA256(payload))
 }

--- a/checksums/main_test.go
+++ b/checksums/main_test.go
@@ -3,10 +3,17 @@ package main
 import "testing"
 
 func TestChecksums(t *testing.T) {
-	if CRC32([]byte("go")) == 0 {
-		t.Fatal("unexpected zero crc32")
+	payload := []byte("invoice:42:paid")
+
+	if got := CRC32(payload); got != 0xd57bb496 {
+		t.Fatalf("CRC32() = %08x, want d57bb496", got)
 	}
-	if CRC64([]byte("go")) == 0 {
-		t.Fatal("unexpected zero crc64")
+
+	if got := CRC64(payload); got != 0x5ca2c9f6a56b90c2 {
+		t.Fatalf("CRC64() = %016x, want 5ca2c9f6a56b90c2", got)
+	}
+
+	if got := SHA256(payload); got != "5caa2109d58ce3fefe483e8b7176b80a00485ecbb3d92b18e48204a6ed4fe876" {
+		t.Fatalf("SHA256() = %s", got)
 	}
 }


### PR DESCRIPTION
## O que mudou

- Expandi o tópico `checksums` com objetivo, pré-requisitos, execução, saída esperada, pontos de atenção e próximos passos.
- Tornei o exemplo executável com `go run .`, mostrando CRC32, CRC64 e SHA-256 para o mesmo payload.
- Troquei testes fracos de "não pode ser zero" por valores esperados fixos.

## Por quê

O tópico estava curto demais para estudo: dizia que existiam `crc32` e `crc64`, mas não mostrava quando CRC é suficiente, quando não é, nem como verificar uma saída concreta. Checksum é uma área onde exemplo vago vira hábito ruim rápido.

## O que não faz

- Não implementa assinatura, HMAC ou verificação com chave.
- Não lê arquivos ainda; o exemplo fica em payload fixo para manter a saída determinística.
- Não mexe na navegação, porque o tópico já estava listado.

## Validação

```bash
$ go fix ./...
$ go fix -inline ./...
$ gofmt -l .
$ go vet ./...
$ golangci-lint run ./...
0 issues.
$ gosec ./...
Issues : 0
$ go test -timeout 30s -count 1 ./...
ok  	checksums	0.002s
$ go run .
crc32  d57bb496
crc64  5ca2c9f6a56b90c2
sha256 5caa2109d58ce3fefe483e8b7176b80a00485ecbb3d92b18e48204a6ed4fe876
```
