### PR TITLE
docs: expand compression topic

### DIFF
--- a/compression_archiving/README.md
+++ b/compression_archiving/README.md
@@ -1,9 +1,50 @@
 # Compressão e arquivamento
 
-Este tópico cobre `compress/gzip` e `archive/zip`.
+Este tópico separa duas ideias que costumam aparecer juntas, mas não são a mesma coisa.
+
+`compress/gzip` comprime um fluxo de bytes. Ele não guarda nome de arquivo, diretório ou lista de entradas. `archive/zip` cria um arquivo com entradas nomeadas; cada entrada pode ter seu próprio conteúdo comprimido. Se você só quer mandar um payload menor pela rede, gzip basta. Se precisa empacotar `relatorio.csv`, `log.txt` e `metadata.json` no mesmo arquivo, aí é zip.
+
+O exemplo fica em memória para não esconder o assunto atrás de caminho de arquivo. O payload é pequeno de propósito: `go study group\n`, 15 bytes. Depois do cabeçalho do gzip, ele vira 39 bytes. Compressão de texto minúsculo pode crescer. Isso não é bug, é overhead.
+
+## Pré-requisitos
+
+- Go 1.26 ou mais recente.
+- Terminal no diretório `compression_archiving`.
+- Noção básica de `[]byte` e tratamento de erro.
+
+## Rodar
+
+```bash
+go run .
+```
+
+Saída esperada:
+
+```text
+gzip roundtrip: "go study group\n"
+gzip bytes: 15 -> 39
+zip files: [note.txt]
+```
+
+A primeira linha confirma o roundtrip: comprimir e descomprimir devolve os mesmos bytes. A segunda mostra o tamanho antes e depois do gzip. A terceira lista o nome salvo dentro do zip.
 
 ## Testar
 
 ```bash
-go test ./...
+go test -timeout 30s -count 1 ./...
 ```
+
+Os testes não tentam provar que gzip "comprime bem". Eles travam o comportamento didático: gzip precisa voltar ao payload original, e o zip precisa carregar a entrada `note.txt`.
+
+## Pontos de atenção
+
+- Feche `gzip.Writer` e `zip.Writer`. Sem `Close`, bytes finais podem ficar no buffer e o arquivo sai inválido.
+- Zip guarda nomes. Nunca extraia um nome vindo de fora direto no disco sem validar caminho; `../../arquivo` é uma armadilha velha e ainda aparece.
+- Gzip não é criptografia. Quem lê o arquivo comprimido também lê o conteúdo.
+- Para arquivo grande, não monte tudo em `bytes.Buffer` como aqui. Use `io.Copy` entre arquivos ou streams.
+
+## Próximos passos
+
+- Ler um arquivo com `os.Open` e gravar o `.gz` com `os.Create`.
+- Criar um zip com mais de uma entrada.
+- Medir com benchmark a diferença entre payload pequeno e payload repetitivo grande.

--- a/compression_archiving/main.go
+++ b/compression_archiving/main.go
@@ -4,18 +4,24 @@ import (
 	"archive/zip"
 	"bytes"
 	"compress/gzip"
+	"fmt"
 	"io"
 )
 
 func GzipBytes(data []byte) ([]byte, error) {
 	var out bytes.Buffer
 	zw := gzip.NewWriter(&out)
-	if _, err := zw.Write(data); err != nil {
+
+	_, err := zw.Write(data)
+	if err != nil {
 		return nil, err
 	}
-	if err := zw.Close(); err != nil {
+
+	err = zw.Close()
+	if err != nil {
 		return nil, err
 	}
+
 	return out.Bytes(), nil
 }
 
@@ -24,22 +30,79 @@ func UngzipBytes(data []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer zr.Close()
-	return io.ReadAll(zr)
+
+	out, readErr := io.ReadAll(zr)
+	closeErr := zr.Close()
+	if readErr != nil {
+		return nil, readErr
+	}
+	if closeErr != nil {
+		return nil, closeErr
+	}
+
+	return out, nil
 }
 
 func ZipSingleFile(name string, content []byte) ([]byte, error) {
 	var out bytes.Buffer
 	zw := zip.NewWriter(&out)
+
 	w, err := zw.Create(name)
 	if err != nil {
 		return nil, err
 	}
-	if _, err := w.Write(content); err != nil {
+
+	_, err = w.Write(content)
+	if err != nil {
 		return nil, err
 	}
-	if err := zw.Close(); err != nil {
+
+	err = zw.Close()
+	if err != nil {
 		return nil, err
 	}
+
 	return out.Bytes(), nil
+}
+
+func ZipFileNames(data []byte) ([]string, error) {
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return nil, err
+	}
+
+	names := make([]string, 0, len(zr.File))
+	for _, file := range zr.File {
+		names = append(names, file.Name)
+	}
+
+	return names, nil
+}
+
+func main() {
+	payload := []byte("go study group\n")
+
+	compressed, err := GzipBytes(payload)
+	if err != nil {
+		panic(err)
+	}
+
+	restored, err := UngzipBytes(compressed)
+	if err != nil {
+		panic(err)
+	}
+
+	archive, err := ZipSingleFile("note.txt", payload)
+	if err != nil {
+		panic(err)
+	}
+
+	names, err := ZipFileNames(archive)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("gzip roundtrip: %q\n", restored)
+	fmt.Printf("gzip bytes: %d -> %d\n", len(payload), len(compressed))
+	fmt.Printf("zip files: %v\n", names)
 }

--- a/compression_archiving/main_test.go
+++ b/compression_archiving/main_test.go
@@ -1,28 +1,41 @@
 package main
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 func TestGzipRoundtrip(t *testing.T) {
-	in := []byte("hello")
-	z, err := GzipBytes(in)
+	in := []byte("go study group\n")
+
+	compressed, err := GzipBytes(in)
 	if err != nil {
 		t.Fatal(err)
 	}
-	out, err := UngzipBytes(z)
+
+	out, err := UngzipBytes(compressed)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(out) != "hello" {
-		t.Fatalf("got %q", out)
+
+	if string(out) != string(in) {
+		t.Fatalf("got %q, want %q", out, in)
 	}
 }
 
 func TestZipSingleFile(t *testing.T) {
-	z, err := ZipSingleFile("a.txt", []byte("x"))
+	archive, err := ZipSingleFile("note.txt", []byte("go study group\n"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(z) == 0 {
-		t.Fatal("empty zip")
+
+	names, err := ZipFileNames(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"note.txt"}
+	if !slices.Equal(names, want) {
+		t.Fatalf("got %v, want %v", names, want)
 	}
 }


### PR DESCRIPTION
Expandi o tópico de compressão para separar `compress/gzip` de `archive/zip`. A versão anterior dizia só quais pacotes existiam; agora o exemplo mostra um roundtrip de gzip, cria um zip com `note.txt` e chama atenção para o caso chato em que payload pequeno cresce por causa do overhead.

Para quem está estudando, isso evita uma confusão comum: gzip comprime bytes, zip guarda entradas nomeadas. Mantive tudo em memória para o exemplo continuar curto. Não cobre extração para disco nem zip com múltiplos arquivos; esses dois pontos entram melhor como próximo exercício, sem empurrar path traversal para dentro do primeiro exemplo.

Validação rodada em `compression_archiving`:

```text
go fix ./...
go fix -inline ./...
gofmt -l .
go vet ./...
golangci-lint run ./...        # 0 issues
gosec ./...                    # Issues: 0
go test -timeout 30s -count 1 ./...  # ok
go run .
```

`go run .`:

```text
gzip roundtrip: "go study group\n"
gzip bytes: 15 -> 39
zip files: [note.txt]
```
