### PR TITLE
docs: expand CSV and TSV topic

### DIFF
--- a/csv_tsv_tabular/README.md
+++ b/csv_tsv_tabular/README.md
@@ -1,9 +1,53 @@
 # CSV, TSV e dados tabulares
 
-Este tópico cobre importação e parsing de dados tabulares com delimitador configurável.
+Arquivo separado por vírgula parece simples até aparecer campo com vírgula dentro, quebra de linha no meio de aspas ou TSV exportado de planilha. Fazer `strings.Split` direto funciona no exemplo de duas colunas e quebra quando o dado fica minimamente real.
+
+Este tópico usa `encoding/csv`, da biblioteca padrão, para ler dados tabulares com delimitador configurável. O mesmo leitor cobre CSV e TSV: muda o `Comma`, não o parser inteiro.
+
+## Objetivo
+
+- Ler registros CSV e TSV sem escrever parser manual.
+- Mostrar por que `FieldsPerRecord = -1` aceita linhas com tamanhos diferentes.
+- Tratar erro de parsing em vez de devolver uma tabela meio lida como se estivesse tudo certo.
+
+## Pré-requisitos
+
+- Go instalado.
+- Saber o básico de slices e strings.
+- Ter visto tratamento de erros com `if err != nil`.
+
+## Executar
+
+```bash
+go run .
+```
+
+Saída esperada:
+
+```text
+name | city | total
+Ana | Santos | 42.50
+Bruno | Recife | 19.90
+```
 
 ## Testar
 
 ```bash
-go test ./...
+go test -timeout 30s -count 1 ./...
 ```
+
+Os testes cobrem leitura com vírgula, leitura com tab, erro de aspas quebradas e a formatação usada pelo `main`.
+
+## Pontos de atenção
+
+`encoding/csv` não é só para vírgula. Para TSV, configure `reader.Comma = '\t'`. Continuar chamando a função de `ParseCSV` quando ela também lê TSV vira ruído rápido; por isso o exemplo usa `ParseDelimited`.
+
+`FieldsPerRecord = -1` deixa o leitor aceitar registros com quantidades diferentes de campos. Isso é útil para logs exportados e dados sujos, mas não valida contrato de schema. Se o arquivo precisa ter exatamente 3 colunas, cheque isso depois de ler.
+
+O erro de `Read` precisa ser tratado dentro do loop. `io.EOF` é o fim normal do arquivo; qualquer outro erro é dado quebrado.
+
+## Próximos passos
+
+- Ler de um `os.File` em vez de uma string.
+- Validar quantidade mínima de colunas por linha.
+- Converter campos numéricos com `strconv.ParseFloat` depois do parsing.

--- a/csv_tsv_tabular/main.go
+++ b/csv_tsv_tabular/main.go
@@ -2,24 +2,51 @@ package main
 
 import (
 	"encoding/csv"
+	"fmt"
 	"io"
+	"os"
 	"strings"
 )
 
-func ParseCSV(data string, comma rune) ([][]string, error) {
-	r := csv.NewReader(strings.NewReader(data))
-	r.Comma = comma
-	r.FieldsPerRecord = -1
-	rows := [][]string{}
+const salesCSV = `name,city,total
+Ana,Santos,42.50
+Bruno,Recife,19.90
+`
+
+func ParseDelimited(data string, comma rune) ([][]string, error) {
+	reader := csv.NewReader(strings.NewReader(data))
+	reader.Comma = comma
+	reader.FieldsPerRecord = -1
+
+	var rows [][]string
 	for {
-		rec, err := r.Read()
+		record, err := reader.Read()
 		if err == io.EOF {
 			break
 		}
 		if err != nil {
 			return nil, err
 		}
-		rows = append(rows, rec)
+		rows = append(rows, record)
 	}
+
 	return rows, nil
+}
+
+func FormatRows(rows [][]string) string {
+	var builder strings.Builder
+	for _, row := range rows {
+		fmt.Fprintf(&builder, "%s\n", strings.Join(row, " | "))
+	}
+	return builder.String()
+}
+
+func main() {
+	rows, err := ParseDelimited(salesCSV, ',')
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "parse delimited data: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Print(FormatRows(rows))
 }

--- a/csv_tsv_tabular/main_test.go
+++ b/csv_tsv_tabular/main_test.go
@@ -2,22 +2,48 @@ package main
 
 import "testing"
 
-func TestParseCSV(t *testing.T) {
-	rows, err := ParseCSV("a,b\nc,d\n", ',')
+func TestParseDelimitedCSV(t *testing.T) {
+	rows, err := ParseDelimited("name,total\nAna,42\n", ',')
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(rows) != 2 || rows[1][1] != "d" {
-		t.Fatalf("unexpected rows: %#v", rows)
+
+	want := "42"
+	got := rows[1][1]
+	if got != want {
+		t.Fatalf("ParseDelimited()[1][1] = %q, want %q", got, want)
 	}
 }
 
-func TestParseTSV(t *testing.T) {
-	rows, err := ParseCSV("a\tb\n", '\t')
+func TestParseDelimitedTSV(t *testing.T) {
+	rows, err := ParseDelimited("name\ttotal\nAna\t42\n", '\t')
 	if err != nil {
 		t.Fatal(err)
 	}
-	if rows[0][1] != "b" {
-		t.Fatalf("unexpected rows: %#v", rows)
+
+	want := "Ana"
+	got := rows[1][0]
+	if got != want {
+		t.Fatalf("ParseDelimited()[1][0] = %q, want %q", got, want)
+	}
+}
+
+func TestParseDelimitedRejectsBrokenQuotes(t *testing.T) {
+	_, err := ParseDelimited("name,total\nAna,\"42\n", ',')
+	if err == nil {
+		t.Fatal("ParseDelimited() error = nil, want parse error")
+	}
+}
+
+func TestFormatRows(t *testing.T) {
+	rows := [][]string{
+		{"name", "city", "total"},
+		{"Ana", "Santos", "42.50"},
+	}
+
+	want := "name | city | total\nAna | Santos | 42.50\n"
+	got := FormatRows(rows)
+	if got != want {
+		t.Fatalf("FormatRows() = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## O que mudou

Expandi o tópico `csv_tsv_tabular`: o README agora explica o uso de `encoding/csv` para CSV e TSV, o exemplo passou a ter `main` executável e os testes cobrem vírgula, tab, aspas quebradas e a formatação da saída.

## Por quê

Esse é um daqueles tópicos em que `strings.Split` parece suficiente até o primeiro arquivo exportado de planilha vir com aspas ou delimitador diferente. Melhor mostrar logo o leitor certo da stdlib e onde o erro aparece.

## O que não faz

Não entra em inferência de schema, conversão automática de tipos nem leitura de arquivo grande em streaming. Aqui a meta é só parsing tabular pequeno e previsível.

## Validação

No diretório `csv_tsv_tabular`:

```bash
go fix ./...
go fix -inline ./...
gofmt -l .
go vet ./...
golangci-lint run ./...
gosec ./...
go test -timeout 30s -count 1 ./...
go run .
```

Resultados relevantes:

```text
golangci-lint: 0 issues.
gosec: Issues : 0
ok  	csv_tsv_tabular	0.002s
name | city | total
Ana | Santos | 42.50
Bruno | Recife | 19.90
```
