### PR TITLE
docs: expand filesystem topic

### DIFF
--- a/filesystem_iofs/README.md
+++ b/filesystem_iofs/README.md
@@ -1,9 +1,52 @@
 # Diretórios e `io/fs`
 
-Este tópico cobre caminhada de diretórios, leitura de metadados e abstração de filesystem.
+`io/fs` é o ponto em que o código para de depender de "arquivo no disco" e passa a depender de um filesystem. Parece detalhe, mas muda o desenho do exemplo: a mesma função consegue ler um diretório real com `os.DirFS`, arquivos embutidos com `embed.FS` ou um filesystem falso no teste com `fstest.MapFS`.
+
+Este tópico usa `fs.WalkDir` para percorrer uma árvore, `fs.Stat` para ler metadados e `fstest.MapFS` para deixar o exemplo pequeno. Nada de criar arquivo temporário só para provar que a lógica funciona.
+
+## Objetivo
+
+- Percorrer diretórios com `fs.WalkDir`.
+- Listar apenas arquivos regulares, ignorando diretórios.
+- Ler tamanho de arquivo por `fs.Stat` sem acoplar a função a `os.Stat`.
+
+## Pré-requisitos
+
+- Go 1.26 ou mais recente.
+- Saber o básico de slices e tratamento de erros.
+- Ter visto interfaces, porque `fs.FS` é uma interface pequena.
+
+## Executar
+
+```bash
+go run .
+```
+
+Saída esperada:
+
+```text
+assets/logo.txt 2 bytes
+docs/readme.md 6 bytes
+```
 
 ## Testar
 
 ```bash
-go test ./...
+go test -timeout 30s -count 1 ./...
 ```
+
+Os testes usam `testing/fstest.MapFS` para montar uma árvore em memória com `a.txt`, `notes/` e `notes/b.txt`. Isso cobre o caso que costuma dar bug em exemplo apressado: `WalkDir` visita diretórios também, então filtrar por `IsDir` ou por arquivo regular não é opcional.
+
+## Pontos de atenção
+
+`fs.WalkDir` trabalha com caminhos separados por `/`, mesmo no Windows. Não misture isso com `filepath.Join` dentro de uma função que recebe `fs.FS`; `path` e os caminhos do próprio pacote `io/fs` são o encaixe certo ali.
+
+`os.DirFS(".")` é útil para ligar a abstração ao disco, mas ele não prende o código dentro do diretório se alguém passar caminho com `..`. Para ferramenta local didática, tudo bem. Para limite de segurança, não trate `DirFS` como sandbox.
+
+`DirEntry.Type()` nem sempre tem todos os bits de tipo preenchidos. Neste exemplo, `IsRegular` funciona com `fstest.MapFS` e com arquivos comuns. Se o código precisar seguir symlink, inspecionar permissão ou diferenciar dispositivos, chame `Info()` e lide com o erro.
+
+## Próximos passos
+
+- Trocar `fstest.MapFS` por `os.DirFS(".")` e listar arquivos do diretório atual.
+- Usar `embed.FS` para empacotar arquivos de exemplo no binário.
+- Adicionar um filtro por extensão usando `path.Ext`, não `filepath.Ext`, quando o dado vem de `fs.FS`.

--- a/filesystem_iofs/main.go
+++ b/filesystem_iofs/main.go
@@ -1,33 +1,54 @@
 package main
 
 import (
+	"fmt"
 	"io/fs"
-	"os"
-	"path/filepath"
+	"log"
+	"testing/fstest"
 )
 
-func ListFiles(root string) ([]string, error) {
-	out := []string{}
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+func ListRegularFiles(fsys fs.FS, root string) ([]string, error) {
+	files := []string{}
+	err := fs.WalkDir(fsys, root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if d.IsDir() {
+		if !d.Type().IsRegular() {
 			return nil
 		}
-		out = append(out, filepath.Base(path))
+		files = append(files, path)
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
-	return out, nil
+	return files, nil
 }
 
-func ReadFileSize(path string) (int64, error) {
-	info, err := os.Stat(path)
+func FileSize(fsys fs.FS, path string) (int64, error) {
+	info, err := fs.Stat(fsys, path)
 	if err != nil {
 		return 0, err
 	}
 	return info.Size(), nil
+}
+
+func main() {
+	demoFS := fstest.MapFS{
+		"assets/logo.txt": {Data: []byte("go")},
+		"docs/readme.md":  {Data: []byte("hello\n")},
+	}
+
+	files, err := ListRegularFiles(demoFS, ".")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, file := range files {
+		size, err := FileSize(demoFS, file)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("%s %d bytes\n", file, size)
+	}
 }

--- a/filesystem_iofs/main_test.go
+++ b/filesystem_iofs/main_test.go
@@ -1,21 +1,51 @@
 package main
 
 import (
-	"os"
-	"path/filepath"
+	"errors"
+	"io/fs"
+	"reflect"
 	"testing"
+	"testing/fstest"
 )
 
-func TestListFiles(t *testing.T) {
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("a"), 0o644); err != nil {
-		t.Fatal(err)
+func TestListRegularFiles(t *testing.T) {
+	fsys := fstest.MapFS{
+		"a.txt":       {Data: []byte("a")},
+		"notes":       {Mode: fs.ModeDir},
+		"notes/b.txt": {Data: []byte("b")},
 	}
-	files, err := ListFiles(dir)
+
+	files, err := ListRegularFiles(fsys, ".")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(files) != 1 || files[0] != "a.txt" {
-		t.Fatalf("unexpected files: %#v", files)
+
+	expected := []string{"a.txt", "notes/b.txt"}
+	if !reflect.DeepEqual(files, expected) {
+		t.Fatalf("files = %#v, want %#v", files, expected)
+	}
+}
+
+func TestFileSize(t *testing.T) {
+	fsys := fstest.MapFS{
+		"message.txt": {Data: []byte("hello\n")},
+	}
+
+	size, err := FileSize(fsys, "message.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if size != 6 {
+		t.Fatalf("size = %d, want 6", size)
+	}
+}
+
+func TestFileSizeMissingFile(t *testing.T) {
+	fsys := fstest.MapFS{}
+
+	_, err := FileSize(fsys, "missing.txt")
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("err = %v, want fs.ErrNotExist", err)
 	}
 }


### PR DESCRIPTION
Expande o tópico de diretórios e `io/fs`, que ainda estava só no esqueleto.

A mudança troca o exemplo acoplado a `filepath.WalkDir`/`os.Stat` por funções que recebem `fs.FS`. Isso deixa o ponto didático mais claro: a mesma lógica funciona com `os.DirFS`, `embed.FS` ou `fstest.MapFS`, sem depender de arquivo temporário no teste.

Também deixei o exemplo executável com `go run .` e com saída documentada no README. Não cobre `embed` em detalhe nem trata `os.DirFS` como sandbox; os dois ficam como próximos passos, porque aqui o foco é a interface pequena de `io/fs`.

Validação no diretório `filesystem_iofs`:

```text
go fix ./...                         OK
go fix -inline ./...                 OK
gofmt -l .                           OK, sem arquivos listados
go vet ./...                         OK
golangci-lint run ./...              OK, 0 issues
gosec ./...                          OK, 0 issues
go test -timeout 30s -count 1 ./...  OK
go run .                             OK
```

Saída do `go run .`:

```text
assets/logo.txt 2 bytes
docs/readme.md 6 bytes
```
