### PR TITLE
docs: expand HTTP fundamentals topic

### DIFF
--- a/http_fundamentals/README.md
+++ b/http_fundamentals/README.md
@@ -1,9 +1,54 @@
 # Fundamentos de HTTP
 
-Este tópico cobre cliente/servidor básico, rotas simples, headers e status codes.
+Este tópico mostra o mínimo útil de HTTP no Go: um `http.Handler`, uma resposta JSON, headers e status codes.
+
+A ideia aqui não é montar um framework caseiro. `net/http` já entrega o contrato principal: uma função recebe `*http.Request`, escreve em `http.ResponseWriter` e decide o status antes de mandar o corpo. Para muita API interna pequena, esse desenho aguenta mais tempo do que parece.
+
+## Pré-requisitos
+
+- Go instalado.
+- Noção básica de funções e structs.
+
+## Exemplo
+
+O arquivo `main.go` tem um handler de health check:
+
+```go
+func HealthHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(message{Status: "ok"})
+}
+```
+
+Três detalhes importam mais do que o tamanho do código:
+
+- o método HTTP é validado antes de escrever o corpo;
+- o header `Content-Type` sai junto da resposta JSON;
+- quando o método é recusado, o handler informa `Allow: GET`, que é o que um cliente decente espera ler num `405 Method Not Allowed`.
 
 ## Testar
 
+Use `httptest` para testar o handler sem abrir porta local:
+
 ```bash
-go test ./...
+go test -timeout 30s -count 1 ./...
 ```
+
+O teste cobre o happy path (`GET /health`) e o erro de método (`POST /health`). Isso força o exemplo a tratar status, header e corpo como parte do contrato, não como detalhe visual do navegador.
+
+## Pontos de atenção
+
+- Depois que o corpo começa a ser escrito, mudar status code já virou tarde demais.
+- Header precisa ser definido antes da primeira escrita no `ResponseWriter`.
+- `http.Error` escreve texto simples. Se a API inteira promete JSON, o erro também precisa seguir esse formato. Este exemplo não faz isso para não misturar middleware e negociação de erro no primeiro contato com HTTP.
+
+## Próximos passos
+
+- Adicionar um `http.ServeMux` com duas rotas pequenas.
+- Testar query string com `r.URL.Query()`.
+- Separar o formato de erro JSON quando o tópico avançar para APIs.

--- a/http_fundamentals/main.go
+++ b/http_fundamentals/main.go
@@ -11,6 +11,7 @@ type message struct {
 
 func HealthHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}

--- a/http_fundamentals/main_test.go
+++ b/http_fundamentals/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -13,6 +14,20 @@ func TestHealthHandler(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d", w.Code)
 	}
+
+	contentType := w.Header().Get("Content-Type")
+	if contentType != "application/json" {
+		t.Fatalf("content-type = %q", contentType)
+	}
+
+	var body message
+	err := json.NewDecoder(w.Body).Decode(&body)
+	if err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Status != "ok" {
+		t.Fatalf("status body = %q", body.Status)
+	}
 }
 
 func TestHealthHandlerMethod(t *testing.T) {
@@ -21,5 +36,9 @@ func TestHealthHandlerMethod(t *testing.T) {
 	HealthHandler(w, r)
 	if w.Code != http.StatusMethodNotAllowed {
 		t.Fatalf("status = %d", w.Code)
+	}
+	allow := w.Header().Get("Allow")
+	if allow != http.MethodGet {
+		t.Fatalf("allow = %q", allow)
 	}
 }


### PR DESCRIPTION
Expandi o tópico de HTTP, que ainda estava só com uma frase e o comando de teste.

A mudança mantém o exemplo pequeno: `net/http`, um health check JSON e `httptest`. O detalhe novo no código é o `Allow: GET` no `405`, porque isso é contrato HTTP real e dá um bom gancho para iniciantes entenderem que status, header e corpo caminham juntos.

Não entra em `ServeMux`, middleware, servidor escutando porta ou erro JSON padronizado. Isso fica para um próximo passo; aqui a aula continua focada no handler.

Validação feita em `http_fundamentals`:

```text
go fix ./...
go fix -inline ./...
gofmt -l .
go vet ./...
golangci-lint run ./...        # 0 issues
gosec ./...                    # Issues: 0
go test -timeout 30s -count 1 ./...  # ok http_fundamentals 0.003s
```
