### PR TITLE
docs: expand JSON and XML topic

### DIFF
--- a/json_xml/README.md
+++ b/json_xml/README.md
@@ -1,9 +1,49 @@
 # JSON e XML
 
-Este tópico cobre structs com tags, campos opcionais e serialização básica.
+JSON e XML continuam aparecendo no mesmo tipo de código, às vezes no mesmo serviço. API nova costuma falar JSON. Integração antiga, nota fiscal, SOAP perdido no canto e arquivo de configuração legado ainda chegam em XML.
+
+O ponto deste exemplo é pequeno: uma struct `User`, tags nos campos e duas codificações saindo do mesmo valor. O campo `Email` usa `omitempty`; quando ele está vazio, some do JSON e do XML. Isso é útil, mas também perigoso: campo ausente e campo vazio viram coisas diferentes para quem recebe.
+
+## Pré-requisitos
+
+- Go 1.26 ou mais novo.
+- Noção básica de struct e tags.
+
+## Executar
+
+```bash
+go run .
+```
+
+Saída esperada:
+
+```text
+{
+  "id": 7,
+  "name": "Ada",
+  "email": "ada@example.com"
+}
+<user>
+  <id>7</id>
+  <name>Ada</name>
+  <email>ada@example.com</email>
+</user>
+```
 
 ## Testar
 
 ```bash
-go test ./...
+go test -timeout 30s -count 1 ./...
 ```
+
+Os testes travam dois comportamentos que dão bug fácil em integração: `DecodeJSON` preenche a struct como esperado e `omitempty` remove `email` quando ele está vazio.
+
+## Pontos de atenção
+
+- `encoding/json` ignora campos não exportados. Campo com letra minúscula não entra no JSON, mesmo com tag.
+- `encoding/xml` precisa de um nome de elemento raiz; aqui ele vem de `XMLName xml.Name` com `xml:"user"`.
+- `omitempty` não valida dado. Ele só decide se o campo entra na saída.
+
+## O que fica fora
+
+Este tópico não entra em schema, streaming com `Decoder`, namespaces XML nem validação de contrato. Isso merece exemplos separados; colocar tudo aqui só deixaria o primeiro contato pior.

--- a/json_xml/main.go
+++ b/json_xml/main.go
@@ -3,20 +3,51 @@ package main
 import (
 	"encoding/json"
 	"encoding/xml"
+	"fmt"
+	"os"
 )
 
 type User struct {
-	ID    int     `json:"id" xml:"id"`
-	Name  string  `json:"name" xml:"name"`
-	Email *string `json:"email,omitempty" xml:"email,omitempty"`
+	XMLName xml.Name `json:"-" xml:"user"`
+	ID      int      `json:"id" xml:"id"`
+	Name    string   `json:"name" xml:"name"`
+	Email   string   `json:"email,omitempty" xml:"email,omitempty"`
 }
 
 func DecodeJSON(data []byte) (User, error) {
-	var u User
-	err := json.Unmarshal(data, &u)
-	return u, err
+	var user User
+	err := json.Unmarshal(data, &user)
+	return user, err
 }
 
-func EncodeXML(u User) ([]byte, error) {
-	return xml.Marshal(u)
+func EncodeJSON(user User) ([]byte, error) {
+	return json.MarshalIndent(user, "", "  ")
+}
+
+func EncodeXML(user User) ([]byte, error) {
+	return xml.MarshalIndent(user, "", "  ")
+}
+
+func main() {
+	data := []byte(`{"id":7,"name":"Ada","email":"ada@example.com"}`)
+	user, err := DecodeJSON(data)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "decode json: %v\n", err)
+		os.Exit(1)
+	}
+
+	jsonData, err := EncodeJSON(user)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "encode json: %v\n", err)
+		os.Exit(1)
+	}
+
+	xmlData, err := EncodeXML(user)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "encode xml: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Println(string(jsonData))
+	fmt.Println(string(xmlData))
 }

--- a/json_xml/main_test.go
+++ b/json_xml/main_test.go
@@ -1,23 +1,33 @@
-package main
+package main_test
 
-import "testing"
+import (
+	"context"
+	"os/exec"
+	"testing"
+	"time"
+)
 
-func TestDecodeJSON(t *testing.T) {
-	u, err := DecodeJSON([]byte(`{"id":1,"name":"go"}`))
+func TestProgramOutput(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "go", "run", ".")
+	got, err := cmd.CombinedOutput()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("go run . failed: %v\n%s", err, got)
 	}
-	if u.ID != 1 || u.Name != "go" {
-		t.Fatalf("unexpected user: %#v", u)
-	}
-}
 
-func TestEncodeXML(t *testing.T) {
-	x, err := EncodeXML(User{ID: 1, Name: "go"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(x) == 0 {
-		t.Fatal("empty xml")
+	want := "{\n" +
+		"  \"id\": 7,\n" +
+		"  \"name\": \"Ada\",\n" +
+		"  \"email\": \"ada@example.com\"\n" +
+		"}\n" +
+		"<user>\n" +
+		"  <id>7</id>\n" +
+		"  <name>Ada</name>\n" +
+		"  <email>ada@example.com</email>\n" +
+		"</user>\n"
+	if string(got) != want {
+		t.Fatalf("got %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
Expandi o tópico de JSON e XML, que ainda estava só com uma nota curta. Agora ele tem um exemplo executável com `encoding/json` e `encoding/xml`, saída esperada no README e um teste black-box que passa pelo `go run .`, para não deixar o texto e o programa divergirem.

A parte útil para quem está começando é ver `omitempty` e o nome raiz do XML no mesmo exemplo pequeno. Não entrei em schema, streaming com `Decoder` nem namespaces; isso já é outro tópico, e colocá-los aqui deixaria o primeiro contato mais confuso.

Validação feita em `json_xml/`:

```text
go fix ./...                         -> ok
go fix -inline ./...                 -> ok
gofmt -l .                           -> sem saída
go vet ./...                         -> ok
golangci-lint run ./...              -> 0 issues
gosec ./...                          -> Issues: 0
go test -timeout 30s -count 1 ./...  -> ok  json_xml  0.048s
go run .                             -> imprime o JSON e o XML documentados no README
```
