### PR TITLE
docs: expand channels select topic

### DIFF
--- a/channels_select/README.md
+++ b/channels_select/README.md
@@ -1,6 +1,13 @@
 # Canais e select
 
-Este tópico cobre comunicação entre goroutines, timeout e `select`.
+Este exemplo mostra uma situação pequena e comum: duas goroutines podem responder, mas o programa só precisa da primeira resposta. O `select` espera o primeiro canal que ficar pronto e também dá uma saída de segurança com timeout.
+
+O detalhe que vale reparar não está só no `select`. Os canais `fast` e `slow` têm buffer de 1. Sem esse buffer, se o timeout ganhasse antes de uma goroutine enviar o valor, ela poderia ficar presa tentando escrever para um canal que ninguém mais lê. Para um exemplo de estudo isso parece pequeno; em serviço rodando por dias, esse tipo de vazamento vira fila de goroutine parada.
+
+## Pré-requisitos
+
+- Go 1.26 ou mais recente.
+- Noção básica de goroutine e canal.
 
 ## Executar
 
@@ -8,8 +15,28 @@ Este tópico cobre comunicação entre goroutines, timeout e `select`.
 go run .
 ```
 
+Saída esperada:
+
+```text
+fast
+```
+
+O retorno é `fast` porque essa goroutine dorme 10ms, enquanto a outra dorme 50ms. Se o timeout passado para `FirstSignal` for menor que o primeiro envio, o resultado passa a ser `timeout`.
+
 ## Testar
 
 ```bash
-go test ./...
+go test -timeout 30s -count 1 ./...
 ```
+
+Os testes cobrem dois caminhos: a primeira resposta vencendo e o timeout vencendo. Eles ainda usam tempos pequenos, então servem bem para enxergar o comportamento, mas não são um modelo para teste pesado de concorrência.
+
+## Pontos de atenção
+
+- `select` não consulta os casos em ordem; quando mais de um canal está pronto, a escolha é pseudoaleatória.
+- `time.After` é ótimo para exemplos curtos. Em loops ou caminhos quentes, prefira `time.NewTimer` e pare o timer quando ele não for mais usado.
+- Canal sem buffer exige alguém lendo no mesmo ritmo de quem escreve. Buffer pequeno pode ser uma decisão consciente, não um remendo.
+
+## Próximos passos
+
+Troque os tempos em `main.go` e rode os testes de novo. Depois, tente remover o buffer dos canais e pense no que acontece quando o timeout vence antes dos envios.


### PR DESCRIPTION
Expandi o tópico de canais e `select`, que ainda estava só no esqueleto. O README agora explica o caso didático do exemplo: duas goroutines competindo pela primeira resposta, timeout como saída segura e o motivo prático do buffer de 1 nos canais.

Isso ajuda quem está começando a não decorar `select` como sintaxe isolada. O ponto perigoso aqui é concreto: sem alguém lendo, uma goroutine pode ficar presa no envio. O texto não tenta cobrir cancelamento com `context`, fan-in/fan-out ou padrões maiores de concorrência; fica só neste exemplo pequeno.

Validação executada em `channels_select`:

```text
go fix ./...                       ok
go fix -inline ./...               ok
gofmt -l .                         sem saída
go vet ./...                       ok
golangci-lint run ./...            ok
gosec ./...                        0 issues
go test -timeout 30s -count 1 ./... ok
go run .                           fast
```
