### PR TITLE
docs: expand goroutines waitgroup topic

### DIFF
--- a/goroutines_waitgroup/README.md
+++ b/goroutines_waitgroup/README.md
@@ -1,9 +1,53 @@
 # Goroutines e WaitGroup
 
-Este tópico mostra concorrência básica com `sync.WaitGroup`.
+`goroutine` é a unidade básica de concorrência em Go: você chama uma função com `go` e ela passa a rodar em paralelo com o fluxo atual. O problema aparece logo depois: se o `main` terminar antes dessas funções, o processo acaba e o trabalho some junto.
+
+`sync.WaitGroup` resolve esse caso pequeno: contar tarefas, marcar cada término e esperar a contagem voltar para zero.
+
+## Pré-requisitos
+
+- saber declarar slices e funções;
+- entender que concorrência não promete ordem de execução;
+- ter Go 1.26 ou mais novo instalado.
+
+## O exemplo
+
+O programa calcula quadrados em goroutines separadas e guarda cada resultado no mesmo índice da entrada. Esse detalhe importa: a ordem em que as goroutines terminam varia, mas o slice final continua previsível.
+
+```go
+values := []int{2, 3, 4, 5}
+fmt.Printf("in=%v out=%v\n", values, ConcurrentSquare(values))
+```
+
+Saída verificada com `go run .`:
+
+```text
+in=[2 3 4 5] out=[4 9 16 25]
+```
+
+## O que observar no código
+
+- `wg.Add(len(values))` acontece antes do loop. Chamar `Add` dentro da goroutine cria uma corrida entre "comecei a esperar" e "avisei que existe trabalho".
+- `defer wg.Done()` fica no começo da função anônima. Se alguém adicionar um `return` mais tarde, a contagem ainda fecha.
+- O loop passa `i` e `v` como argumentos da função anônima. Fica explícito qual valor aquela goroutine deve usar.
+
+## Executar
+
+```bash
+go run .
+```
 
 ## Testar
 
 ```bash
-go test ./...
+go test -timeout 30s -count 1 ./...
 ```
+
+## Erros comuns
+
+- esquecer `Done` e deixar `Wait` preso para sempre;
+- chamar `Add` depois de iniciar a goroutine;
+- escrever em estruturas compartilhadas sem separar os índices ou sem sincronização;
+- esperar que a ordem de término das goroutines seja igual à ordem do loop.
+
+Este exemplo não tenta limitar o número de goroutines. Para quatro itens isso é ótimo. Para 40 mil, o próximo assunto é worker pool ou semáforo com canal.

--- a/goroutines_waitgroup/main_test.go
+++ b/goroutines_waitgroup/main_test.go
@@ -3,11 +3,35 @@ package main
 import "testing"
 
 func TestConcurrentSquare(t *testing.T) {
-	got := ConcurrentSquare([]int{2, 3, 4})
-	want := []int{4, 9, 16}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Fatalf("got[%d]=%d want=%d", i, got[i], want[i])
-		}
+	tests := []struct {
+		name   string
+		values []int
+		want   []int
+	}{
+		{
+			name:   "keeps input order",
+			values: []int{2, 3, 4},
+			want:   []int{4, 9, 16},
+		},
+		{
+			name:   "empty input",
+			values: nil,
+			want:   []int{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := ConcurrentSquare(test.values)
+			if len(got) != len(test.want) {
+				t.Fatalf("got len=%d want=%d", len(got), len(test.want))
+			}
+
+			for i := range test.want {
+				if got[i] != test.want[i] {
+					t.Fatalf("got[%d]=%d want=%d", i, got[i], test.want[i])
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Ampliei o tópico de `sync.WaitGroup`, que ainda estava quase só como placeholder. O README agora explica o caso didático sem transformar isso em aula de scheduler: iniciar goroutines, contar trabalho com `Add`, fechar com `Done` e preservar a ordem do resultado pelo índice do slice.

Também deixei o teste um pouco menos frágil: ele cobre entrada vazia e valida o tamanho antes de olhar os índices. Não entra em worker pool, cancelamento ou limite de concorrência; isso fica para outro tópico, porque aqui a ideia é só entender o primeiro `WaitGroup` sem ruído.

Validação no diretório `goroutines_waitgroup`:

```text
go fix ./...                         ok
go fix -inline ./...                 ok
gofmt -l .                           sem saída
go vet ./...                         ok
golangci-lint run ./...              0 issues
gosec ./...                          Issues: 0
go test -timeout 30s -count 1 ./...  ok goroutines_waitgroup 0.002s
go run .                             in=[2 3 4 5] out=[4 9 16 25]
```
