### PR TITLE
docs: expand context cancellation topic

### DIFF
--- a/context_cancellation/README.md
+++ b/context_cancellation/README.md
@@ -1,6 +1,13 @@
 # Context
 
-Este tópico cobre deadline, cancelamento e propagação de `context.Context`.
+`context.Context` é o jeito normal de avisar uma goroutine que o trabalho perdeu o sentido: a requisição caiu, o prazo acabou, ou o chamador decidiu cancelar. Sem esse fio de cancelamento, código concorrente continua rodando no escuro e você só percebe quando o teste fica lento ou o processo começa a juntar goroutine parada.
+
+Este exemplo mostra um trabalho pequeno que termina sozinho ou para quando o contexto fecha.
+
+## Pré-requisitos
+
+- Go 1.26 ou mais recente.
+- Noções básicas de goroutines, canais e `select`.
 
 ## Executar
 
@@ -8,8 +15,36 @@ Este tópico cobre deadline, cancelamento e propagação de `context.Context`.
 go run .
 ```
 
+Saída esperada:
+
+```text
+work finished without cancellation
+canceled with: context deadline exceeded
+```
+
+## O que observar no código
+
+`Work` recebe o contexto como primeiro argumento. Essa convenção parece detalhe, mas ajuda bastante quando a função cresce: quem chama enxerga logo que ela pode ser cancelada.
+
+O `select` espera duas coisas: o timer do trabalho ou `ctx.Done()`. Quando o prazo de 5ms vence antes do trabalho de 50ms, a função devolve `context deadline exceeded`. O erro não é embrulhado aqui de propósito, porque `errors.Is(err, context.DeadlineExceeded)` precisa continuar funcionando no teste.
+
+Também tem uma escolha pequena no timer: o exemplo usa `time.NewTimer` com `defer timer.Stop()` em vez de `time.After`. Para um programa minúsculo os dois funcionam. Em código que roda em loop, parar o timer deixa a intenção mais clara e evita carregar trabalho morto até o runtime limpar.
+
 ## Testar
 
 ```bash
-go test ./...
+go test -timeout 30s -count 1 ./...
 ```
+
+Os testes cobrem o caminho cancelado por deadline e o caminho que termina antes do contexto fechar.
+
+## Erros comuns
+
+- Criar um contexto novo dentro da função em vez de receber o contexto do chamador. Isso corta a propagação do cancelamento.
+- Ignorar `ctx.Err()` e devolver `nil` no cancelamento. O chamador perde a diferença entre trabalho concluído e trabalho abandonado.
+- Guardar `context.Context` em struct para reutilizar depois. Contexto carrega prazo e cancelamento de uma operação específica, não configuração global.
+
+## Próximos passos
+
+- Trocar o timer por uma chamada HTTP com `http.NewRequestWithContext`.
+- Combinar `context.WithCancel` com uma goroutine produtora e conferir se ela para quando o consumidor desiste.

--- a/context_cancellation/main.go
+++ b/context_cancellation/main.go
@@ -7,8 +7,11 @@ import (
 )
 
 func Work(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
 	select {
-	case <-time.After(d):
+	case <-timer.C:
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()
@@ -18,15 +21,19 @@ func Work(ctx context.Context, d time.Duration) error {
 func main() {
 	okCtx, okCancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer okCancel()
-	if err := Work(okCtx, 20*time.Millisecond); err != nil {
+
+	err := Work(okCtx, 20*time.Millisecond)
+	if err != nil {
 		fmt.Println("unexpected:", err)
-	} else {
-		fmt.Println("work finished without cancellation")
+		return
 	}
+	fmt.Println("work finished without cancellation")
 
 	cancelCtx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
 	defer cancel()
-	if err := Work(cancelCtx, 50*time.Millisecond); err != nil {
+
+	err = Work(cancelCtx, 50*time.Millisecond)
+	if err != nil {
 		fmt.Println("canceled with:", err)
 	}
 }


### PR DESCRIPTION
Expandi o tópico de `context.Context` com uma explicação mais concreta sobre deadline, cancelamento e propagação. O README agora mostra a saída real do exemplo e chama atenção para um detalhe que costuma virar bug pequeno: devolver `ctx.Err()` sem esconder `context deadline exceeded`, para o chamador ainda conseguir testar com `errors.Is`.

No código, troquei `time.After` por `time.NewTimer` com `Stop` e tirei o `if err := ...` inline do `main`, mantendo o exemplo simples e dentro do estilo dos tópicos recentes. Não entra em `context.WithValue`, árvore de contexts, nem servidor HTTP; isso fica melhor em outro tópico, porque aqui a aula é só cancelamento.

Validação rodada em `context_cancellation`:

```text
go fix ./...
go fix -inline ./...
gofmt -l .
go vet ./...
golangci-lint run ./...          # 0 issues
gosec ./...                      # Issues: 0
go test -timeout 30s -count 1 ./...  # ok context_cancellation 0.009s
go run .
```

`go run .` imprimiu:

```text
work finished without cancellation
canceled with: context deadline exceeded
```
