### PR TITLE
docs: expand testing in Go topic

### DIFF
--- a/testing_in_go/README.md
+++ b/testing_in_go/README.md
@@ -1,9 +1,57 @@
 # Testes em Go
 
-Este tópico cobre testes em tabela, subtests, `t.Helper` e exemplos executáveis.
+Este tópico mostra três peças que aparecem cedo em teste Go: teste em tabela, subtest com `t.Run` e `t.Helper` para tirar ruído da linha de erro.
 
-## Testar
+O exemplo é pequeno de propósito. `NormalizeSpace` recebe uma string, troca qualquer sequência de whitespace por um espaço ASCII e remove sobra no começo e no fim. Isso dá casos bons para testar sem montar servidor, banco ou fixture.
+
+## Pré-requisitos
+
+- Go 1.26 ou mais recente.
+- Terminal aberto neste diretório: `testing_in_go`.
+
+## O que observar
+
+O teste fica em `package space_test`, não no mesmo pacote do código. Isso força o exemplo a usar a API pública, do mesmo jeito que outro pacote usaria.
+
+`assertEqual` chama `t.Helper()`. Sem isso, uma falha aponta para dentro do helper. Com isso, ela aponta para a linha do subtest que chamou o helper. Parece detalhe pequeno, mas em tabela com 20 casos economiza tempo.
+
+O `ExampleNormalizeSpace` também é teste. O `go test` executa o exemplo e compara a saída com o comentário `// Output:`. Se a saída mudar, o teste quebra.
+
+## Executar os testes
 
 ```bash
-go test ./...
+go test -timeout 30s -count 1 ./...
 ```
+
+Saída esperada:
+
+```text
+ok  	example.com/testing-in-go	...
+```
+
+O tempo no fim varia de máquina para máquina.
+
+## Ver os subtests
+
+```bash
+go test -v ./...
+```
+
+Você deve ver nomes como:
+
+```text
+=== RUN   TestNormalizeSpace/extra_spaces
+=== RUN   TestNormalizeSpace/tabs_and_newlines
+```
+
+Esses nomes vêm do campo `name` da tabela. Quando um caso quebra, o nome do caso quebrado aparece no relatório.
+
+## Erros comuns
+
+- Esquecer `t.Helper()` em helpers de asserção e acabar depurando a linha errada.
+- Usar `t.Fatal` dentro de goroutine criada pelo teste. O teste pode continuar de um jeito que não parece óbvio para iniciante.
+- Testar só o happy path. Aqui o caso com tab, newline e espaços nas pontas existe para pegar exatamente a parte chata da função.
+
+## O que este tópico não cobre
+
+Não entra em mock, teste HTTP, benchmark nem fuzzing. Cada um desses assuntos merece um exemplo próprio; misturar tudo aqui deixaria o primeiro contato com `testing` mais confuso do que útil.

--- a/testing_in_go/go.mod
+++ b/testing_in_go/go.mod
@@ -1,3 +1,3 @@
-module testing_in_go
+module example.com/testing-in-go
 
 go 1.26

--- a/testing_in_go/normalize.go
+++ b/testing_in_go/normalize.go
@@ -1,7 +1,8 @@
-package main
+package space
 
 import "strings"
 
+// NormalizeSpace collapses any run of whitespace into one ASCII space.
 func NormalizeSpace(s string) string {
 	return strings.Join(strings.Fields(s), " ")
 }

--- a/testing_in_go/normalize_test.go
+++ b/testing_in_go/normalize_test.go
@@ -1,8 +1,10 @@
-package main
+package space_test
 
 import (
 	"fmt"
 	"testing"
+
+	space "example.com/testing-in-go"
 )
 
 func assertEqual(t *testing.T, got, want string) {
@@ -21,16 +23,18 @@ func TestNormalizeSpace(t *testing.T) {
 		{"single spaces", "go is fun", "go is fun"},
 		{"extra spaces", "go   is   fun", "go is fun"},
 		{"tabs and newlines", "go\t\nis\tfun", "go is fun"},
+		{"leading and trailing", "  go is fun\n", "go is fun"},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			assertEqual(t, NormalizeSpace(tc.in), tc.want)
+			got := space.NormalizeSpace(tc.in)
+			assertEqual(t, got, tc.want)
 		})
 	}
 }
 
 func ExampleNormalizeSpace() {
-	fmt.Println(NormalizeSpace("go    is\tfun"))
+	fmt.Println(space.NormalizeSpace("go    is\tfun"))
 	// Output: go is fun
 }


### PR DESCRIPTION
Expandi o tópico de testes em Go, que ainda estava quase só como marcador. O README agora explica teste em tabela, subtest, `t.Helper` e example test usando a função pequena que já existia.

Também ajustei o exemplo para ser testado como pacote externo (`space_test`). Isso deixa a aula mais honesta: o teste usa só a API pública, igual outro pacote usaria. Não entra em mock, HTTP, benchmark ou fuzzing; esse tópico fica no primeiro contato com `testing`.

Validação executada em `testing_in_go`:

```text
go fix ./...                         ok
go fix -inline ./...                 ok
gofmt -l .                           sem arquivos
go vet ./...                         ok
golangci-lint run ./...              ok
gosec ./...                          0 issues
go test -timeout 30s -count 1 ./...  ok  example.com/testing-in-go  0.002s
go test -v ./...                     PASS, incluindo ExampleNormalizeSpace
```
