### PR TITLE
docs: expand REST API CRUD topic

### DIFF
--- a/rest_api_crud/README.md
+++ b/rest_api_crud/README.md
@@ -1,9 +1,54 @@
 # API RESTful
 
-Este tópico entrega um CRUD HTTP simples com JSON, validação básica e status codes corretos.
+Este tópico mostra um CRUD HTTP pequeno usando só `net/http`, `encoding/json` e um mapa protegido por `sync.Mutex`. Não tem banco, roteador externo nem middleware: a ideia é enxergar o contrato HTTP sem esconder o básico atrás de framework.
+
+O exemplo trabalha com `/items` e `/items/{id}`:
+
+- `POST /items` cria um item com `name` obrigatório;
+- `GET /items` lista os itens em ordem de `id`, para o teste não depender da ordem interna do mapa;
+- `GET /items/{id}` lê um item;
+- `PUT /items/{id}` troca o nome mantendo o mesmo `id`;
+- `DELETE /items/{id}` remove o item e responde `204 No Content`.
+
+## Pré-requisitos
+
+Go 1.26 ou mais novo.
+
+## Rodar o exemplo
+
+```bash
+go run .
+```
+
+Saída esperada:
+
+```text
+POST /items -> 201
+GET /items/1 -> 200
+PUT /items/1 -> 200
+DELETE /items/1 -> 204
+```
+
+O `main` não sobe uma porta TCP. Ele usa `httptest` para chamar o handler em memória e terminar rápido, o que é melhor para estudo e para CI. Se quiser transformar isso em servidor real depois, o ponto de troca é pequeno: `http.ListenAndServe` recebendo `store.Handler`.
 
 ## Testar
 
 ```bash
-go test ./...
+go test -timeout 30s -count 1 ./...
 ```
+
+O teste cobre o ciclo criar, ler, atualizar, listar e apagar. Também trava um caso chato de API pequena: payload com nome vazio precisa falhar com `400 Bad Request`, não criar lixo no mapa.
+
+## Pontos de atenção
+
+`map` em Go não preserva ordem. Por isso a listagem ordena por `id` antes de gerar JSON. Sem essa linha, o exemplo pode passar hoje e falhar quando tiver mais dados.
+
+O armazenamento é em memória. Reiniciou o processo, perdeu tudo. Isso é proposital: persistência mudaria o assunto para SQL, arquivo ou transação, e este tópico é sobre método HTTP, status code e JSON.
+
+Também não há autenticação, paginação, validação rica ou log estruturado. Tudo isso existe em APIs reais, mas aqui seria barulho antes da hora.
+
+## Próximos passos
+
+- Trocar o mapa por `database/sql` em outro tópico.
+- Separar o handler em pacote próprio quando houver mais rotas.
+- Adicionar `PATCH` só quando fizer sentido discutir atualização parcial.

--- a/rest_api_crud/main.go
+++ b/rest_api_crud/main.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"net/http/httptest"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -38,47 +42,105 @@ func (s *Store) Handler(w http.ResponseWriter, r *http.Request) {
 func (s *Store) handleCollection(w http.ResponseWriter, r *http.Request) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
 	switch r.Method {
 	case http.MethodGet:
 		list := make([]Item, 0, len(s.items))
-		for _, it := range s.items {
-			list = append(list, it)
+		for _, item := range s.items {
+			list = append(list, item)
 		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(list)
+		sort.Slice(list, func(i, j int) bool {
+			return list[i].ID < list[j].ID
+		})
+		writeJSON(w, http.StatusOK, list)
 	case http.MethodPost:
-		var in Item
-		if err := json.NewDecoder(r.Body).Decode(&in); err != nil || strings.TrimSpace(in.Name) == "" {
+		var input Item
+		err := json.NewDecoder(r.Body).Decode(&input)
+		if err != nil || strings.TrimSpace(input.Name) == "" {
 			http.Error(w, "invalid payload", http.StatusBadRequest)
 			return
 		}
-		in.ID = s.next
+		input.ID = s.next
 		s.next++
-		s.items[in.ID] = in
-		w.WriteHeader(http.StatusCreated)
-		_ = json.NewEncoder(w).Encode(in)
+		s.items[input.ID] = input
+		writeJSON(w, http.StatusCreated, input)
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 	}
 }
 
 func (s *Store) handleItem(w http.ResponseWriter, r *http.Request) {
-	idStr := strings.TrimPrefix(r.URL.Path, "/items/")
-	id, err := strconv.Atoi(idStr)
-	if err != nil {
+	id, ok := itemID(r.URL.Path)
+	if !ok {
 		http.Error(w, "invalid id", http.StatusBadRequest)
 		return
 	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if r.Method == http.MethodDelete {
-		if _, ok := s.items[id]; !ok {
-			http.NotFound(w, r)
-			return
-		}
-		delete(s.items, id)
-		w.WriteHeader(http.StatusNoContent)
+
+	item, exists := s.items[id]
+	if !exists {
+		http.NotFound(w, r)
 		return
 	}
-	http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+
+	switch r.Method {
+	case http.MethodGet:
+		writeJSON(w, http.StatusOK, item)
+	case http.MethodPut:
+		var input Item
+		err := json.NewDecoder(r.Body).Decode(&input)
+		if err != nil || strings.TrimSpace(input.Name) == "" {
+			http.Error(w, "invalid payload", http.StatusBadRequest)
+			return
+		}
+		input.ID = id
+		s.items[id] = input
+		writeJSON(w, http.StatusOK, input)
+	case http.MethodDelete:
+		delete(s.items, id)
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func itemID(path string) (int, bool) {
+	value := strings.TrimPrefix(path, "/items/")
+	id, err := strconv.Atoi(value)
+	if err != nil || id < 1 {
+		return 0, false
+	}
+	return id, true
+}
+
+func writeJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
+}
+
+func main() {
+	store := NewStore()
+
+	requests := []struct {
+		method string
+		path   string
+		body   string
+	}{
+		{method: http.MethodPost, path: "/items", body: `{"name":"notebook"}`},
+		{method: http.MethodGet, path: "/items/1"},
+		{method: http.MethodPut, path: "/items/1", body: `{"name":"pen"}`},
+		{method: http.MethodDelete, path: "/items/1"},
+	}
+
+	for _, request := range requests {
+		body := bytes.NewBufferString(request.body)
+		req := httptest.NewRequest(request.method, request.path, body)
+		res := httptest.NewRecorder()
+		store.Handler(res, req)
+
+		fmt.Printf("%s %s -> %d\n", request.method, request.path, res.Code)
+	}
 }

--- a/rest_api_crud/main_test.go
+++ b/rest_api_crud/main_test.go
@@ -2,32 +2,71 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 )
 
 func TestCRUDFlow(t *testing.T) {
-	s := NewStore()
+	store := NewStore()
 
-	createReq := httptest.NewRequest(http.MethodPost, "/items", bytes.NewBufferString(`{"name":"book"}`))
-	createRes := httptest.NewRecorder()
-	s.Handler(createRes, createReq)
+	createRes := request(t, store, http.MethodPost, "/items", `{"name":"book"}`)
 	if createRes.Code != http.StatusCreated {
 		t.Fatalf("create status=%d", createRes.Code)
 	}
 
-	listReq := httptest.NewRequest(http.MethodGet, "/items", nil)
-	listRes := httptest.NewRecorder()
-	s.Handler(listRes, listReq)
+	var created Item
+	err := json.NewDecoder(createRes.Body).Decode(&created)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.ID != 1 || created.Name != "book" {
+		t.Fatalf("created item=%+v", created)
+	}
+
+	getRes := request(t, store, http.MethodGet, "/items/1", "")
+	if getRes.Code != http.StatusOK {
+		t.Fatalf("get status=%d", getRes.Code)
+	}
+
+	updateRes := request(t, store, http.MethodPut, "/items/1", `{"name":"notebook"}`)
+	if updateRes.Code != http.StatusOK {
+		t.Fatalf("update status=%d", updateRes.Code)
+	}
+
+	listRes := request(t, store, http.MethodGet, "/items", "")
 	if listRes.Code != http.StatusOK {
 		t.Fatalf("list status=%d", listRes.Code)
 	}
-
-	delReq := httptest.NewRequest(http.MethodDelete, "/items/1", nil)
-	delRes := httptest.NewRecorder()
-	s.Handler(delRes, delReq)
-	if delRes.Code != http.StatusNoContent {
-		t.Fatalf("delete status=%d", delRes.Code)
+	if listRes.Body.String() != "[{\"id\":1,\"name\":\"notebook\"}]\n" {
+		t.Fatalf("list body=%q", listRes.Body.String())
 	}
+
+	deleteRes := request(t, store, http.MethodDelete, "/items/1", "")
+	if deleteRes.Code != http.StatusNoContent {
+		t.Fatalf("delete status=%d", deleteRes.Code)
+	}
+
+	missingRes := request(t, store, http.MethodGet, "/items/1", "")
+	if missingRes.Code != http.StatusNotFound {
+		t.Fatalf("missing status=%d", missingRes.Code)
+	}
+}
+
+func TestRejectsInvalidPayload(t *testing.T) {
+	store := NewStore()
+	res := request(t, store, http.MethodPost, "/items", `{"name":"   "}`)
+	if res.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d", res.Code)
+	}
+}
+
+func request(t *testing.T, store *Store, method string, path string, body string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req := httptest.NewRequest(method, path, bytes.NewBufferString(body))
+	res := httptest.NewRecorder()
+	store.Handler(res, req)
+	return res
 }


### PR DESCRIPTION
Expandi o tópico de API REST para ser um exemplo completo de CRUD em cima de `net/http`, sem roteador externo e sem banco. O README agora explica o contrato dos endpoints, a escolha de manter tudo em memória e a pegadinha real do `map`: listar sem ordenar deixa o teste depender de detalhe interno da runtime.

Para quem está estudando, o ganho é ver `POST`, `GET`, `PUT` e `DELETE` no mesmo handler, com JSON e status codes pequenos o bastante para caber numa leitura só. Não cobre autenticação, paginação, persistência nem `PATCH`; isso viraria outro assunto antes da hora.

Validação rodada em `rest_api_crud/`:

```text
go fix ./...                              OK
go fix -inline ./...                      OK
gofmt -l .                                OK, sem arquivos listados
go vet ./...                              OK
golangci-lint run ./...                   OK, 0 issues
gosec ./...                               OK, 0 issues
go test -timeout 30s -count 1 ./...       OK
go run .                                  OK
```

`go run .` imprime:

```text
POST /items -> 201
GET /items/1 -> 200
PUT /items/1 -> 200
DELETE /items/1 -> 204
```
