### PR TITLE
docs: expand sync race conditions topic

### DIFF
--- a/sync_and_race_conditions/README.md
+++ b/sync_and_race_conditions/README.md
@@ -1,6 +1,29 @@
 # Sincronização e race conditions
 
-Este tópico cobre `Mutex`, condições de corrida e uso básico de `sync.Map`.
+Um contador compartilhado entre goroutines parece inofensivo até o primeiro `go test -race`. `n++` não é uma operação atômica: lê, soma e grava. Sem coordenação, duas goroutines podem ler o mesmo valor e uma atualização some no caminho.
+
+Este tópico usa `sync.Mutex` para proteger uma seção crítica pequena e `sync.WaitGroup` para esperar as goroutines terminarem. Também mostra `sync.Map`, mas sem vender milagre: ele serve para caches e mapas com acesso concorrente específico, não para substituir `map` em todo código.
+
+## Pré-requisitos
+
+- Go 1.26 ou mais novo.
+- Saber criar goroutines.
+- Ter visto `go test` pelo menos uma vez.
+
+## Executar
+
+```bash
+go run .
+```
+
+Saída esperada:
+
+```text
+counter=100
+cache[go]=2
+```
+
+O número `100` importa. Se o contador fosse incrementado sem o `Mutex`, o teste poderia passar em uma máquina e falhar em outra. Race condition tem esse gosto ruim: o bug existe mesmo quando a execução do dia resolveu colaborar.
 
 ## Testar
 
@@ -8,3 +31,16 @@ Este tópico cobre `Mutex`, condições de corrida e uso básico de `sync.Map`.
 go test ./...
 go test -race ./...
 ```
+
+Use `go test -race` quando mexer em código concorrente. Ele deixa a execução mais lenta, mas encontra acessos compartilhados sem sincronização que uma asserção comum não enxerga.
+
+## Pontos de atenção
+
+- Proteja o menor trecho possível com `Lock` e `Unlock`. Segurar o `Mutex` durante I/O é pedir fila à toa.
+- Use `defer Unlock()` quando a função tem retorno ou erro no meio. No incremento de uma linha, destravar logo abaixo é mais direto.
+- `sync.Map` não preserva ordem. Se precisar imprimir ou comparar valores em ordem estável, copie as chaves para um slice e ordene.
+- `WaitGroup` espera trabalho terminar; ele não protege memória compartilhada. São ferramentas diferentes.
+
+## Próximos passos
+
+Troque o `Mutex` por `sync.RWMutex` em uma versão com muitas leituras e poucas escritas. Depois rode com `go test -race` de novo; se o exemplo não passa no race detector, ele não está pronto para ensinar concorrência.

--- a/sync_and_race_conditions/main.go
+++ b/sync_and_race_conditions/main.go
@@ -1,6 +1,9 @@
 package main
 
-import "sync"
+import (
+	"fmt"
+	"sync"
+)
 
 type Counter struct {
 	mu sync.Mutex
@@ -25,4 +28,33 @@ func FillSyncMap(values []string) *sync.Map {
 		m.Store(v, len(v))
 	}
 	return m
+}
+
+func IncrementConcurrently(workers int) int {
+	var c Counter
+	var wg sync.WaitGroup
+
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			c.Inc()
+		}()
+	}
+	wg.Wait()
+
+	return c.Value()
+}
+
+func main() {
+	count := IncrementConcurrently(100)
+	cache := FillSyncMap([]string{"go", "mutex", "race"})
+
+	value, ok := cache.Load("go")
+	if !ok {
+		panic("missing cache entry")
+	}
+
+	fmt.Printf("counter=%d\n", count)
+	fmt.Printf("cache[go]=%d\n", value)
 }

--- a/sync_and_race_conditions/main_test.go
+++ b/sync_and_race_conditions/main_test.go
@@ -19,15 +19,28 @@ func TestCounterConcurrent(t *testing.T) {
 	}
 	wg.Wait()
 
-	if got := c.Value(); got != workers {
+	got := c.Value()
+	if got != workers {
 		t.Fatalf("counter = %d, want %d", got, workers)
+	}
+}
+
+func TestIncrementConcurrently(t *testing.T) {
+	got := IncrementConcurrently(100)
+	if got != 100 {
+		t.Fatalf("count = %d, want 100", got)
 	}
 }
 
 func TestFillSyncMap(t *testing.T) {
 	m := FillSyncMap([]string{"go", "lang"})
 	v, ok := m.Load("go")
-	if !ok || v.(int) != 2 {
-		t.Fatalf("unexpected map value: %#v", v)
+	if !ok {
+		t.Fatal("missing map value")
+	}
+
+	got := v.(int)
+	if got != 2 {
+		t.Fatalf("map value = %d, want 2", got)
 	}
 }


### PR DESCRIPTION
Expandi o tópico de sincronização e race conditions sem puxar nada fora da standard library.

A mudança deixa o exemplo executável com `go run .`, mantém o contador protegido por `sync.Mutex`, reaproveita `sync.WaitGroup` para a espera das goroutines e mostra `sync.Map` como cache concorrente pequeno, não como substituto universal de `map`. O README agora bate no ponto que costuma pegar iniciante: `n++` parece uma operação só, mas não é.

Não cobre `atomic`, `Cond` nem desenho avançado de lock. Melhor não colocar três assuntos de concorrência no mesmo degrau.

Validação rodada em `sync_and_race_conditions`:

```text
go fix ./...
go fix -inline ./...
gofmt -l .
go vet ./...
golangci-lint run ./...        # 0 issues.
gosec ./...                    # Issues: 0
go test -timeout 30s -count 1 ./...       # ok sync_and_race_conditions 0.002s
go test -race -timeout 30s -count 1 ./... # ok sync_and_race_conditions 1.010s
go run .
```

Saída do `go run .`:

```text
counter=100
cache[go]=2
```
